### PR TITLE
remove unreachable code and add a gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+spiderweb

--- a/crawler.go
+++ b/crawler.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	"golang.org/x/net/html"
 	"net/http"
 	"strings"
+
+	"golang.org/x/net/html"
 )
 
-func crawlLink(rootUrl string, givenUrl string) []string {
+func crawlLink(rootURL string, givenURL string) []string {
 	// Normalise Given URL
-	givenUrl = normalisePath(givenUrl)
+	givenURL = normalisePath(givenURL)
 
 	// Make GET request
-	resp, _ := http.Get(givenUrl)
+	resp, _ := http.Get(givenURL)
 	body := resp.Body
 
 	// Extract links
@@ -25,30 +26,28 @@ func crawlLink(rootUrl string, givenUrl string) []string {
 		case tokenType == html.StartTagToken:
 			token := page.Token()
 			if token.Data == "a" {
-				link := getHref(token, givenUrl)
-				if len(link)>1 {
+				link := getHref(token, givenURL)
+				if len(link) > 1 {
 					link = normalisePath(link)
-					if strings.Contains(link, rootUrl) {
+					if strings.Contains(link, rootURL) {
 						links = append(links, link)
 					}
 				}
 			}
 		case tokenType == html.ErrorToken:
+			body.Close()
 			return links
 		}
 	}
-
-	body.Close()
-	return links
 }
 
 func crawlSite(rootUrl string, depth *int) []string {
 	// Default to 2 depth - 1 call
 	var maxDepth int
 	if depth == nil {
-		 maxDepth = 1
+		maxDepth = 1
 	} else {
-		maxDepth = *depth-1
+		maxDepth = *depth - 1
 	}
 
 	// Begin by crawling root
@@ -57,7 +56,6 @@ func crawlSite(rootUrl string, depth *int) []string {
 	// Return multiple links
 	return links
 }
-
 
 func crawlSiteForLinks(rootUrl string, link string, givenLinks *[]string, maxDepth int, currentDepth int) []string {
 	var links []string
@@ -73,7 +71,7 @@ func crawlSiteForLinks(rootUrl string, link string, givenLinks *[]string, maxDep
 			links = append(links, crawledLink)
 		}
 		if maxDepth > currentDepth {
-			links = crawlSiteForLinks(rootUrl, crawledLink, &links, maxDepth, currentDepth + 1)
+			links = crawlSiteForLinks(rootUrl, crawledLink, &links, maxDepth, currentDepth+1)
 		}
 	}
 	return links
@@ -107,4 +105,3 @@ func getHref(token html.Token, url string) string {
 
 	return ""
 }
-

--- a/crawler.go
+++ b/crawler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -12,8 +13,14 @@ func crawlLink(rootURL string, givenURL string) []string {
 	givenURL = normalisePath(givenURL)
 
 	// Make GET request
-	resp, _ := http.Get(givenURL)
+	resp, err := http.Get(givenURL)
+
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+	}
+
 	body := resp.Body
+	defer body.Close()
 
 	// Extract links
 	links := []string{}
@@ -35,7 +42,6 @@ func crawlLink(rootURL string, givenURL string) []string {
 				}
 			}
 		case tokenType == html.ErrorToken:
-			body.Close()
 			return links
 		}
 	}


### PR DESCRIPTION
- There was some unreachable code in crawler.go (line 40-42):

```go

	body.Close()
	return links

```

which was fixed by making body close automatically using `defer`

- Handle the error in `http.get`

- Formatted code using `gofmt`

- Added a git-ignore, to ignore the binaries.